### PR TITLE
Fix build error

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -15,3 +15,7 @@
 /**
  * @type {Cypress.PluginConfig}
  */
+
+module.exports = function (on, config) {
+  // configure plugins here
+}


### PR DESCRIPTION
The `pluginsFile` must export a function with the following signature:

module.exports = function (on, config) {
  // configure plugins here
}